### PR TITLE
WEBRTC-2478: Fix GitHub Action for Javadoc generation

### DIFF
--- a/.github/workflows/generate-javadoc.yml
+++ b/.github/workflows/generate-javadoc.yml
@@ -15,12 +15,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
       
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -33,14 +33,14 @@ jobs:
         run: ./gradlew :library:generateJavadoc
       
       - name: Upload Javadoc
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: javadoc
-          path: library/build/docs/javadoc
+          path: docs
       
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: library/build/docs/javadoc
+          folder: docs
           branch: gh-pages
           clean: true


### PR DESCRIPTION
## Description
This PR fixes the GitHub Action for Javadoc generation as requested in WEBRTC-2478.

### Changes:
- Updated actions/upload-artifact from v3 to v4 to fix the deprecation error
- Updated actions/checkout from v3 to v4 for consistency
- Updated actions/setup-java from v3 to v4 for consistency
- Changed path to generated javadoc to "docs" to match where gradle will save generated javadocs

## Jira Ticket
[WEBRTC-2478](https://telnyx.atlassian.net/browse/WEBRTC-2478)

[WEBRTC-2478]: https://telnyx.atlassian.net/browse/WEBRTC-2478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ